### PR TITLE
Add VCF download and remove campaign status restrictions

### DIFF
--- a/src/components/nurse/NurseAssignedCampaigns.tsx
+++ b/src/components/nurse/NurseAssignedCampaigns.tsx
@@ -233,6 +233,16 @@ END:VCARD`;
     toast.success("URL copied to clipboard!");
   };
 
+  const handleDownloadVCF = (url: GeneratedURL) => {
+    const link = document.createElement("a");
+    link.href = url.vcfUrl;
+    link.download = `${url.doctorName.replace(/\s+/g, "_")}_contact.vcf`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    toast.success("VCF card downloaded!");
+  };
+
   const openUrlModal = (campaign: NurseCampaignApiData) => {
     setSelectedCampaign(campaign);
     setIsUrlModalOpen(true);

--- a/src/components/nurse/NurseAssignedCampaigns.tsx
+++ b/src/components/nurse/NurseAssignedCampaigns.tsx
@@ -446,7 +446,6 @@ END:VCARD`;
                       onClick={() => openUrlModal(campaign)}
                       size="sm"
                       className="gap-2"
-                      disabled={campaign.campaignStatus !== "active"}
                     >
                       <Link className="w-4 h-4" />
                       Generate URL

--- a/src/components/nurse/NurseAssignedCampaigns.tsx
+++ b/src/components/nurse/NurseAssignedCampaigns.tsx
@@ -544,17 +544,24 @@ END:VCARD`;
                       </Badge>
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button
-                        onClick={() =>
-                          window.open(urlData.patientUrl, "_blank")
-                        }
-                        size="sm"
-                        variant="outline"
-                        className="gap-2"
-                      >
-                        <ExternalLink className="w-4 h-4" />
-                        Open
-                      </Button>
+                      <div className="flex items-center gap-2 justify-end">
+                        <Button
+                          onClick={() => handleDownloadVCF(urlData)}
+                          size="sm"
+                          variant="outline"
+                        >
+                          <Download className="w-4 h-4" />
+                        </Button>
+                        <Button
+                          onClick={() =>
+                            window.open(urlData.patientUrl, "_blank")
+                          }
+                          size="sm"
+                          variant="outline"
+                        >
+                          <ExternalLink className="w-4 h-4" />
+                        </Button>
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/components/nurse/NurseAssignedCampaigns.tsx
+++ b/src/components/nurse/NurseAssignedCampaigns.tsx
@@ -41,6 +41,7 @@ import {
   Upload,
   Loader2,
   User,
+  Download,
 } from "lucide-react";
 import { toast } from "sonner";
 

--- a/src/components/nurse/NurseCampaignDetail.tsx
+++ b/src/components/nurse/NurseCampaignDetail.tsx
@@ -297,11 +297,7 @@ END:VCARD`;
             Campaign details and URL management
           </p>
         </div>
-        <Button
-          onClick={() => setIsUrlModalOpen(true)}
-          className="gap-2"
-          disabled={campaign.campaignStatus !== "active"}
-        >
+        <Button onClick={() => setIsUrlModalOpen(true)} className="gap-2">
           <Link className="w-4 h-4" />
           Generate URL
         </Button>


### PR DESCRIPTION
This change adds VCF contact card download functionality and removes campaign status restrictions from URL generation.

Changes made:
- Added Download icon import from lucide-react
- Added handleDownloadVCF function to create and trigger VCF file downloads
- Added download button with Download icon in the URL table actions
- Removed disabled prop from "Generate URL" buttons that was checking campaign status
- Updated table cell layout to display download and open buttons side by side

The VCF download creates a contact file named after the doctor and triggers a success toast notification.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6c48ea3b6f4a4b6c99ea5720f5df8c8f/flare-landing)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6c48ea3b6f4a4b6c99ea5720f5df8c8f</projectId>-->
<!--<branchName>flare-landing</branchName>-->