### PR TITLE
Replace static data with API calls in CampaignFormModal

### DIFF
--- a/src/components/forms/CampaignFormModal.tsx
+++ b/src/components/forms/CampaignFormModal.tsx
@@ -369,13 +369,7 @@ const CampaignFormModal = ({
   };
 
   const updateCampaign = async (campaignData: CampaignPayload) => {
-    const userString = localStorage.getItem("user");
-    if (!userString) {
-      throw new Error("No authentication token found");
-    }
-
-    const user = JSON.parse(userString);
-    const token = user.token;
+    const token = getAuthToken();
 
     const response = await fetch(
       "https://1q34qmastc.execute-api.us-east-1.amazonaws.com/dev/campaign/update",


### PR DESCRIPTION
This change replaces static brand and nurse data with dynamic API calls in the CampaignFormModal component.

Changes made:
- Added Loader2 icon import from lucide-react
- Extended Brand and Nurse interfaces with additional properties (logo_url, description, brandStatus, created_by, created_at, updated_at, assigned_campaigns, assigned_admins)
- Removed static brand and nurse arrays
- Added state variables for brands, nurses, and loading states
- Implemented getAuthToken() helper function for authentication
- Added fetchBrands() and fetchNurses() API functions
- Added useEffect to fetch data when modal opens
- Updated nurse creation to use dynamic state instead of static array
- Added loading indicators and disabled states for form elements during API calls
- Updated button states to handle loading conditions
- Filtered brands by active status in the select dropdown

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c1643bc46d174d2c828e151b91a14976/pulse-nest)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c1643bc46d174d2c828e151b91a14976</projectId>-->
<!--<branchName>pulse-nest</branchName>-->