### PR TITLE
Hide Generate URL button for draft/UAT campaigns

### DIFF
--- a/src/components/dashboard/CampaignDetailSection.tsx
+++ b/src/components/dashboard/CampaignDetailSection.tsx
@@ -598,7 +598,7 @@ END:VCARD`;
       {/* Generated URLs Table */}
       <Card>
         <CardHeader>
-          <CardTitle>Generated Patient URLs</CardTitle>
+          <CardTitle>Generated Contact cards</CardTitle>
           <CardDescription>
             Track and manage URLs generated for this campaign
           </CardDescription>

--- a/src/components/dashboard/CampaignDetailSection.tsx
+++ b/src/components/dashboard/CampaignDetailSection.tsx
@@ -493,10 +493,13 @@ END:VCARD`;
             <Link className="w-4 h-4" />
             View Campaign URLs
           </Button>
-          <Button onClick={() => setIsUrlModalOpen(true)} className="gap-2">
-            <Link className="w-4 h-4" />
-            Generate URL
-          </Button>
+          {campaign.campaignStatus?.toLowerCase() !== "draft" &&
+            campaign.campaignStatus?.toLowerCase() !== "uat" && (
+              <Button onClick={() => setIsUrlModalOpen(true)} className="gap-2">
+                <Link className="w-4 h-4" />
+                Generate URL
+              </Button>
+            )}
         </div>
       </div>
 

--- a/src/components/dashboard/CampaignDetailSection.tsx
+++ b/src/components/dashboard/CampaignDetailSection.tsx
@@ -865,24 +865,6 @@ END:VCARD`;
                 rows={3}
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="logo">Logo (optional)</Label>
-              <div className="relative">
-                <Upload className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
-                <Input
-                  id="logo"
-                  type="file"
-                  accept="image/*"
-                  onChange={handleFileChange}
-                  className="pl-10"
-                />
-              </div>
-              {formData.logo && (
-                <p className="text-sm text-muted-foreground">
-                  Selected: {formData.logo.name}
-                </p>
-              )}
-            </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={resetUrlForm}>

--- a/src/components/nurse/NurseAssignedCampaigns.tsx
+++ b/src/components/nurse/NurseAssignedCampaigns.tsx
@@ -465,14 +465,17 @@ END:VCARD`;
                     {new Date(campaign.created_at).toLocaleDateString()}
                   </TableCell>
                   <TableCell className="text-right">
-                    <Button
-                      onClick={() => openUrlModal(campaign)}
-                      size="sm"
-                      className="gap-2"
-                    >
-                      <Link className="w-4 h-4" />
-                      Generate URL
-                    </Button>
+                    {campaign.campaignStatus?.toLowerCase() !== "draft" &&
+                      campaign.campaignStatus?.toLowerCase() !== "uat" && (
+                        <Button
+                          onClick={() => openUrlModal(campaign)}
+                          size="sm"
+                          className="gap-2"
+                        >
+                          <Link className="w-4 h-4" />
+                          Generate URL
+                        </Button>
+                      )}
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/components/nurse/NurseAssignedCampaigns.tsx
+++ b/src/components/nurse/NurseAssignedCampaigns.tsx
@@ -485,7 +485,7 @@ END:VCARD`;
       {generatedUrls.length > 0 && (
         <Card>
           <CardHeader>
-            <CardTitle>Generated Patient URLs</CardTitle>
+            <CardTitle>Generated Contact cards</CardTitle>
             <CardDescription>
               Track and manage URLs you've generated for patients
             </CardDescription>

--- a/src/components/nurse/NurseAssignedCampaigns.tsx
+++ b/src/components/nurse/NurseAssignedCampaigns.tsx
@@ -656,24 +656,6 @@ END:VCARD`;
                 rows={3}
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="logo">Logo (optional)</Label>
-              <div className="relative">
-                <Upload className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
-                <Input
-                  id="logo"
-                  type="file"
-                  accept="image/*"
-                  onChange={handleFileChange}
-                  className="pl-10"
-                />
-              </div>
-              {formData.logo && (
-                <p className="text-sm text-muted-foreground">
-                  Selected: {formData.logo.name}
-                </p>
-              )}
-            </div>
           </div>
           <DialogFooter>
             <Button

--- a/src/components/nurse/NurseCampaignDetail.tsx
+++ b/src/components/nurse/NurseCampaignDetail.tsx
@@ -413,7 +413,7 @@ END:VCARD`;
       {/* Generated URLs Table */}
       <Card>
         <CardHeader>
-          <CardTitle>Generated Patient URLs</CardTitle>
+          <CardTitle>Generated Contact cards</CardTitle>
           <CardDescription>
             Track and manage URLs you've generated for this campaign
           </CardDescription>

--- a/src/components/nurse/NurseCampaignDetail.tsx
+++ b/src/components/nurse/NurseCampaignDetail.tsx
@@ -314,10 +314,13 @@ END:VCARD`;
             <Link className="w-4 h-4" />
             View Campaign URLs
           </Button>
-          <Button onClick={() => setIsUrlModalOpen(true)} className="gap-2">
-            <Link className="w-4 h-4" />
-            Generate URL
-          </Button>
+          {campaign?.campaignStatus?.toLowerCase() !== "draft" &&
+            campaign?.campaignStatus?.toLowerCase() !== "uat" && (
+              <Button onClick={() => setIsUrlModalOpen(true)} className="gap-2">
+                <Link className="w-4 h-4" />
+                Generate URL
+              </Button>
+            )}
         </div>
       </div>
 

--- a/src/components/nurse/NurseCampaignDetail.tsx
+++ b/src/components/nurse/NurseCampaignDetail.tsx
@@ -599,24 +599,6 @@ END:VCARD`;
                 rows={3}
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="logo">Logo (optional)</Label>
-              <div className="relative">
-                <Upload className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
-                <Input
-                  id="logo"
-                  type="file"
-                  accept="image/*"
-                  onChange={handleFileChange}
-                  className="pl-10"
-                />
-              </div>
-              {formData.logo && (
-                <p className="text-sm text-muted-foreground">
-                  Selected: {formData.logo.name}
-                </p>
-              )}
-            </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={resetForm}>

--- a/src/pages/GeneratedURLs.tsx
+++ b/src/pages/GeneratedURLs.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import DashboardLayout from "@/components/layout/DashboardLayout";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -42,6 +43,7 @@ import {
   ArrowLeft,
 } from "lucide-react";
 import { toast } from "sonner";
+import type { UserRole } from "./Login";
 
 interface GeneratedURL {
   id: string;

--- a/src/pages/GeneratedURLs.tsx
+++ b/src/pages/GeneratedURLs.tsx
@@ -518,8 +518,8 @@ const GeneratedURLs = () => {
                         >
                           <ExternalLink className="w-4 h-4" />
                         </Button>
-                        {(userRole === "superAdmin" ||
-                          userRole === "admin") && (
+                        {(user?.role === "superAdmin" ||
+                          user?.role === "admin") && (
                           <Button
                             onClick={() => handleDeleteUrl(urlData.id)}
                             size="sm"

--- a/src/pages/GeneratedURLs.tsx
+++ b/src/pages/GeneratedURLs.tsx
@@ -224,7 +224,15 @@ const GeneratedURLs = () => {
 
   const stats = getStatusStats();
 
-  return (
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
+  const renderContent = () => (
     <div className="space-y-6">
       {/* Back Button */}
       <div className="flex items-center">

--- a/src/pages/GeneratedURLs.tsx
+++ b/src/pages/GeneratedURLs.tsx
@@ -122,6 +122,7 @@ const GeneratedURLs = () => {
   const campaignId = searchParams.get("campaignId");
   const campaignName = searchParams.get("campaignName");
 
+  const [user, setUser] = useState<User | null>(null);
   const [generatedUrls, setGeneratedUrls] =
     useState<GeneratedURL[]>(mockGeneratedUrls);
   const [searchTerm, setSearchTerm] = useState("");
@@ -129,23 +130,28 @@ const GeneratedURLs = () => {
   const [campaignFilter, setCampaignFilter] = useState<string>(
     campaignId || "all",
   );
-  const [userRole, setUserRole] = useState<"superAdmin" | "admin" | "nurse">(
-    "admin",
-  );
 
   useEffect(() => {
-    // Get user role from localStorage
-    const storedUser = localStorage.getItem("user");
-    if (storedUser) {
-      const user = JSON.parse(storedUser);
-      setUserRole(user.role || "nurse");
+    // Check authentication
+    const userData = localStorage.getItem("user");
+    if (!userData) {
+      navigate("/");
+      return;
     }
+
+    const parsedUser = JSON.parse(userData);
+    if (!parsedUser.isAuthenticated) {
+      navigate("/");
+      return;
+    }
+
+    setUser(parsedUser);
 
     // Set campaign filter if coming from specific campaign
     if (campaignId) {
       setCampaignFilter(campaignId);
     }
-  }, [campaignId]);
+  }, [campaignId, navigate]);
 
   // Filter URLs based on search term and filters
   const filteredUrls = generatedUrls.filter((url) => {

--- a/src/pages/GeneratedURLs.tsx
+++ b/src/pages/GeneratedURLs.tsx
@@ -549,6 +549,17 @@ const GeneratedURLs = () => {
       </Card>
     </div>
   );
+
+  return (
+    <DashboardLayout
+      userRole={user.role}
+      userEmail={user.email}
+      activeSection="generated-urls"
+      onSectionChange={() => {}}
+    >
+      {renderContent()}
+    </DashboardLayout>
+  );
 };
 
 export default GeneratedURLs;

--- a/src/pages/GeneratedURLs.tsx
+++ b/src/pages/GeneratedURLs.tsx
@@ -526,18 +526,6 @@ const GeneratedURLs = () => {
                         >
                           <ExternalLink className="w-4 h-4" />
                         </Button>
-                        {(user?.role === "superAdmin" ||
-                          user?.role === "admin") && (
-                          <Button
-                            onClick={() => handleDeleteUrl(urlData.id)}
-                            size="sm"
-                            variant="outline"
-                            title="Delete URL"
-                            className="text-destructive hover:text-destructive"
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </Button>
-                        )}
                       </div>
                     </TableCell>
                   </TableRow>

--- a/src/pages/GeneratedURLs.tsx
+++ b/src/pages/GeneratedURLs.tsx
@@ -248,7 +248,7 @@ const GeneratedURLs = () => {
         <p className="text-muted-foreground mt-1">
           {campaignName
             ? `View and manage patient URLs for ${campaignName}`
-            : "View and manage all generated patient URLs across campaigns"}
+            : "View and manage all generated contact cards across campaigns"}
         </p>
       </div>
 

--- a/src/pages/GeneratedURLs.tsx
+++ b/src/pages/GeneratedURLs.tsx
@@ -45,6 +45,12 @@ import {
 import { toast } from "sonner";
 import type { UserRole } from "./Login";
 
+interface User {
+  email: string;
+  role: UserRole;
+  isAuthenticated: boolean;
+}
+
 interface GeneratedURL {
   id: string;
   campaignId: string;

--- a/src/pages/GeneratedURLs.tsx
+++ b/src/pages/GeneratedURLs.tsx
@@ -38,7 +38,6 @@ import {
   Globe,
   User,
   FileText,
-  Trash2,
   Edit,
   ArrowLeft,
 } from "lucide-react";

--- a/src/pages/GeneratedURLs.tsx
+++ b/src/pages/GeneratedURLs.tsx
@@ -205,11 +205,6 @@ const GeneratedURLs = () => {
     toast.success("URL status updated!");
   };
 
-  const handleDeleteUrl = (urlId: string) => {
-    setGeneratedUrls((urls) => urls.filter((url) => url.id !== urlId));
-    toast.success("URL deleted successfully!");
-  };
-
   const getStatusStats = () => {
     // Use filtered URLs if viewing specific campaign, otherwise all URLs
     const urlsToCount = campaignId


### PR DESCRIPTION
This change adds conditional rendering to hide the "Generate URL" button when campaigns have a status of "draft" or "uat".

Changes made:
- Added campaign status checks in CampaignDetailSection.tsx, NurseAssignedCampaigns.tsx, and NurseCampaignDetail.tsx
- Generate URL button now only displays when campaign status is not "draft" or "uat"
- Updated card titles from "Generated Patient URLs" to "Generated Contact cards"
- Removed logo upload functionality from URL generation forms
- Added proper authentication checks and DashboardLayout wrapper to GeneratedURLs.tsx
- Removed delete URL functionality from the URLs table

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c1643bc46d174d2c828e151b91a14976/quantum-lab)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c1643bc46d174d2c828e151b91a14976</projectId>-->
<!--<branchName>quantum-lab</branchName>-->